### PR TITLE
fixes for compatibility with build 270

### DIFF
--- a/components/Breadcrumbs.php
+++ b/components/Breadcrumbs.php
@@ -85,6 +85,15 @@ class Breadcrumbs extends ComponentBase
         foreach ($pages as $page) {
             //strip off forward slash
 
+            $page->addVisible([
+                    'crumb_title', 
+                    'crumbElementTitle', 
+                    'crumb_disabled', 
+                    'remove_crumb_trail', 
+                    'hide_crumb', 
+                    'child_of'
+            ]);
+
             $pagesList[$page->baseFileName] = [
                 'baseFileName'   => $page->baseFileName,
                 'url'            => $page->url,


### PR DESCRIPTION
This commit fixes the problem, when all custom properties of page are not visible by default, after build 270.
More details [here](http://octobercms.com/plugin/mey-breadcrumbs/crash-plugin-after-october-update?page=1)
