### PR TITLE
Fix for compatibility with 286 build.

### DIFF
--- a/components/Breadcrumbs.php
+++ b/components/Breadcrumbs.php
@@ -83,16 +83,6 @@ class Breadcrumbs extends ComponentBase
     {
         $pagesList = [];
         foreach ($pages as $page) {
-            //strip off forward slash
-
-            $page->addVisible([
-                    'crumb_title', 
-                    'crumbElementTitle', 
-                    'crumb_disabled', 
-                    'remove_crumb_trail', 
-                    'hide_crumb', 
-                    'child_of'
-            ]);
 
             $pagesList[$page->baseFileName] = [
                 'baseFileName'   => $page->baseFileName,


### PR DESCRIPTION
@daftspunk Rollback the idea of using $visible in [this commit](https://github.com/octobercms/october/commit/0f215785f340b912c12b993a59ff236f8a0e31af), so it`s needed fix the component in the plugin.
I've removed this feature too.
